### PR TITLE
Add support to add aliases for individual sensors

### DIFF
--- a/resources/properties/properties.xml
+++ b/resources/properties/properties.xml
@@ -1,0 +1,16 @@
+<resources>
+
+<properties>
+  <property id="sensor-01-mac-address" type="string"></property>
+  <property id="sensor-01-alias" type="string"></property>
+  <property id="sensor-02-mac-address" type="string"></property>
+  <property id="sensor-02-alias" type="string"></property>
+  <property id="sensor-03-mac-address" type="string"></property>
+  <property id="sensor-03-alias" type="string"></property>
+  <property id="sensor-04-mac-address" type="string"></property>
+  <property id="sensor-04-alias" type="string"></property>
+  <property id="sensor-05-mac-address" type="string"></property>
+  <property id="sensor-05-alias" type="string"></property>
+</properties>
+
+</resources>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -1,0 +1,42 @@
+<resources>
+
+<settings>
+
+  <setting propertyKey="@Properties.sensor-01-mac-address" title="@Strings.Sensor01macAddress_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+  <setting propertyKey="@Properties.sensor-01-alias" title="@Strings.Sensor01alias_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+
+  <setting propertyKey="@Properties.sensor-02-mac-address" title="@Strings.Sensor02macAddress_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+  <setting propertyKey="@Properties.sensor-02-alias" title="@Strings.Sensor02alias_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+
+  <setting propertyKey="@Properties.sensor-03-mac-address" title="@Strings.Sensor03macAddress_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+  <setting propertyKey="@Properties.sensor-03-alias" title="@Strings.Sensor03alias_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+
+  <setting propertyKey="@Properties.sensor-04-mac-address" title="@Strings.Sensor04macAddress_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+  <setting propertyKey="@Properties.sensor-04-alias" title="@Strings.Sensor04alias_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+
+  <setting propertyKey="@Properties.sensor-05-mac-address" title="@Strings.Sensor05macAddress_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+  <setting propertyKey="@Properties.sensor-05-alias" title="@Strings.Sensor05alias_title">
+  <settingConfig type="alphaNumeric" />
+  </setting>
+
+</settings>
+
+</resources>

--- a/resources/strings.xml
+++ b/resources/strings.xml
@@ -4,5 +4,15 @@
 	    <string id="Scanning">Scanning...</string>
 	    <string id="Found">found</string>
 	    <string id="SecondsAgo">s ago</string>
+	    <string id="Sensor01macAddress_title">Sensor 1 Hardware Address</string>
+	    <string id="Sensor01alias_title">Sensor 1 Alias</string>
+	    <string id="Sensor02macAddress_title">Sensor 2 Hardware Address</string>
+	    <string id="Sensor02alias_title">Sensor 2 Alias</string>
+	    <string id="Sensor03macAddress_title">Sensor 3 Hardware Address</string>
+	    <string id="Sensor03alias_title">Sensor 3 Alias</string>
+	    <string id="Sensor04macAddress_title">Sensor 4 Hardware Address</string>
+	    <string id="Sensor04alias_title">Sensor 4 Alias</string>
+	    <string id="Sensor05macAddress_title">Sensor 5 Hardware Address</string>
+	    <string id="Sensor05alias_title">Sensor 5 Alias</string>
 	</strings>
 </resources>

--- a/source/RuuviTagApp.mc
+++ b/source/RuuviTagApp.mc
@@ -28,9 +28,10 @@ class RuuviTagApp extends Application.AppBase {
     bleDelegate_ = new RuuviTagBleDelegate(method(:onRuuviTagData));
   }
 
-  function onStart(state) {
-    for (var i = 1; i < 6; i++) {
-      var sensor = "sensor-" + i.format("%02d");
+  private function readProperties() {
+    for (var i = 0; i < 5; i++) {
+      var sensorIndex = i + 1;
+      var sensor = "sensor-" + sensorIndex.format("%02d");
       var sensorMacAddress;
       var sensorAlias;
 
@@ -50,6 +51,10 @@ class RuuviTagApp extends Application.AppBase {
          */
       }
     }
+  }
+
+  function onStart(state) {
+    readProperties();
   }
 
   function getInitialView() {

--- a/source/RuuviTagApp.mc
+++ b/source/RuuviTagApp.mc
@@ -43,6 +43,11 @@ class RuuviTagApp extends Application.AppBase {
         }
       }
       catch(ex) {
+        /* When Application.Properties.getValue() throws an exception, the
+         * widget will work - just without displaying sensor aliases. Handle
+         * such exceptions as a warning and not as an error and, thus don't
+         * crash the widget.
+         */
       }
     }
   }

--- a/source/RuuviTagApp.mc
+++ b/source/RuuviTagApp.mc
@@ -28,20 +28,6 @@ class RuuviTagApp extends Application.AppBase {
     bleDelegate_ = new RuuviTagBleDelegate(method(:onRuuviTagData));
   }
 
-  private function verifySensorProperty (sensorMacAddress, sensorAlias) {
-    var sensorMacAddressCA = sensorMacAddress.toCharArray();
-
-    // verify if format of user-configurable hardware address is reasonable
-    if ((sensorMacAddress.length() == 14) && 
-        (sensorMacAddressCA[2] ==
-         sensorMacAddressCA[5] ==
-         sensorMacAddressCA[8] ==
-         sensorMacAddressCA[11] == ':')) {
-        return true;
-      }
-    return false;
-  }
-
   function onStart(state) {
     for (var i = 1; i < 6; i++) {
       var sensor = "sensor-" + i.format("%02d");
@@ -52,7 +38,7 @@ class RuuviTagApp extends Application.AppBase {
         sensorMacAddress = Application.Properties.getValue(sensor + "-mac-address");
         sensorAlias = Application.Properties.getValue(sensor + "-alias");
 
-        if (verifySensorProperty(sensorMacAddress, sensorAlias)) {
+        if (sensorMacAddress.length() > 0 && sensorAlias.length() > 0) {
           sensorAliases_[sensorMacAddress.toUpper()] = sensorAlias;
         }
       }

--- a/source/RuuviTagBle.mc
+++ b/source/RuuviTagBle.mc
@@ -159,6 +159,10 @@ class RuuviTagBleDelegate extends BluetoothLowEnergy.BleDelegate {
 
   function initialize(callback) {
     callback_ = callback;
+    
+    Application.Properties.setValue("sensor-01-mac-address", "CO:FF:EE:47:11");
+    Application.Properties.setValue("sensor-01-alias", "Kitchen");
+    
     timers_ = [
       createInterval(:notifyTag1, 1000),
       createInterval(:notifyTag2, 2100)
@@ -203,6 +207,23 @@ class RuuviTagBleDelegate extends BluetoothLowEnergy.BleDelegate {
       :movementCounter => 1,
       :measurementSequenceNumber => measurementSequenceNumber_,
       :macAddress => "01:02:03:04:05",
+    });
+
+    callback_.invoke("fake3", {
+      :rssiDbm => Math.rand() % 10 - 80,
+      :humidityPercent => (Math.rand() % 20) / 10f + 40f,
+      :temperatureDegC => (Math.rand() % 50) / 10f + 20f,
+      :pressurePa => -(Math.rand() % 1000) + 90000,
+      :accelerationMilliG => {
+        :x => 707,
+        :y => -707,
+        :z => 0,
+      },
+      :batteryMilliVolts => 2700,
+      :transmitPowerDbm => 3,
+      :movementCounter => 1,
+      :measurementSequenceNumber => measurementSequenceNumber_,
+      :macAddress => "CO:FF:EE:47:11",
     });
   }
 }

--- a/source/RuuviTagSensor.mc
+++ b/source/RuuviTagSensor.mc
@@ -62,14 +62,14 @@ class RuuviTagSensorView extends WatchUi.View {
     ]);
   }
 
-  private function getSensorAlias(macAddress) {
+  private function getSensorDisplayName(macAddress) {
     return (sensorAliases_[macAddress]) ? sensorAliases_[macAddress] : macAddress;
   }
 
   function onUpdate(dc) {
     View.onUpdate(dc);
     if (data_.hasKey(:macAddress)) {
-      View.findDrawableById("address").setText(getSensorAlias(data_[:macAddress]));
+      View.findDrawableById("address").setText(getSensorDisplayName(data_[:macAddress]));
     }
     View.findDrawableById("humidity").setText(
       getHumidityLabelText(data_[:humidityPercent]));

--- a/source/RuuviTagSensor.mc
+++ b/source/RuuviTagSensor.mc
@@ -5,6 +5,7 @@ class RuuviTagSensorView extends WatchUi.View {
   private var labelSecondsAgo = WatchUi.loadResource(Rez.Strings.SecondsAgo);
 
   private var data_ = null;
+  private var sensorAliases_ = null;
   private var showNextPageArrow_ = false;
   private var lastUpdated_ = null;
 
@@ -61,10 +62,14 @@ class RuuviTagSensorView extends WatchUi.View {
     ]);
   }
 
+  private function getSensorAlias(macAddress) {
+    return (sensorAliases_[macAddress]) ? sensorAliases_[macAddress] : macAddress;
+  }
+
   function onUpdate(dc) {
     View.onUpdate(dc);
     if (data_.hasKey(:macAddress)) {
-      View.findDrawableById("address").setText(data_[:macAddress]);
+      View.findDrawableById("address").setText(getSensorAlias(data_[:macAddress]));
     }
     View.findDrawableById("humidity").setText(
       getHumidityLabelText(data_[:humidityPercent]));
@@ -84,8 +89,9 @@ class RuuviTagSensorView extends WatchUi.View {
     }
   }
 
-  function setContent(data, showNextPageArrow) {
+  function setContent(data, sensorAliases, showNextPageArrow) {
     data_ = data;
+    sensorAliases_ = sensorAliases;
     showNextPageArrow_ = showNextPageArrow;
     lastUpdated_ = Time.now();
   }


### PR DESCRIPTION
This patch series adds aliasing support for up to five individual sensors.

Rationale: Currently, the RuuviTag Widget shows only the hardware address (MAC address) for sensors that broadcast their data using the RuuviTag version 5 protocol.

Goal: Instead of showing the hardware address, it would be nice to display a user-configurable, human-readable alias which helps to identify the location of the individual sensor. For example, aliases like "Kitchen", "Balcony", or "Dungeon", are displayed for sensors with hardware addresses "CO:FF:EE:47:11", "01:02:03:04:05", or "DE:AD:BE:EF:00".

Editing aliases is achieved by using either the "IQ Apps" module of the "Garmin Express" application (Windows, macOS) or the "Connect IQ" application (My Device -> My Widgets -> Installed -> RuuviTag Widget -> Settings) on Android (and iOS?).

Developers notes: aliases can be edited directly using the Garmin SDK or within the code.

Garmin SDK:

- run RuuviTag Widget in the simulator
- switch to the SDK and choose: "Connnect IQ" -> "App Settings Editor"
- choose "RuuviTag" from the project combo box
- if configuration options are not shown, activate "Rebuild" 

Code examples:

Application.Properties.setValue("sensor-01-mac-address", "CO:FF:EE:47:11");
Application.Properties.setValue("sensor-01-alias", "Kitchen");

[1] https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_05.md